### PR TITLE
Better seeding and faster stream mixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The prng counter based and has a 64-bit state, hence it has a cycle of 2^64. Her
 
     class random {
     public:
-        explicit random(uint64_t seed) : _counter(seed) {}
+        explicit random(uint64_t seed) : _counter(mix(seed + C)) {}
         uint64_t operator()() { return mix(_counter++); }
     private:
         uint64_t _counter;
@@ -61,7 +61,7 @@ mixer|MSVC, Threadripper 3970<span>@</span>3.7GHz, ms|MSVC, i7-4790k@4GHz, ms|Cl
 nop|1133|1148|1300|-
 splitmix|4047|4716|7917|16
 mx3_rev1|4213|4688|7557|21
-mx3_rev2|5173|5975|10335|>42
+mx3_rev2|5173|5975|10335|>45
 
 * mx3::hash the speed is according to SMHasher for large keys 8000-9000 MiB/sec and for small keys about 40-50 cycles/hash.
 

--- a/mx3.h
+++ b/mx3.h
@@ -31,11 +31,30 @@ private:
 
 namespace internal {
 
+inline uint64_t mix_stream(uint64_t h, uint64_t a, uint64_t b, uint64_t c, uint64_t d) {
+	a *= C;
+	b *= C;
+	c *= C;
+	d *= C;
+	a ^= (a >> 57) ^ (a >> 33);
+	b ^= (b >> 57) ^ (b >> 33);
+	c ^= (c >> 57) ^ (c >> 33);
+	d ^= (d >> 57) ^ (d >> 33);
+	h += a * C;
+	h *= C;
+	h += b * C;
+	h *= C;
+	h += c * C;
+	h *= C;
+	h += d * C;
+	h *= C;
+	return h;
+}
+
 inline uint64_t mix_stream(uint64_t h, uint64_t x) {
 	x *= C;
-	x ^= (x >> 57) ^ (x >> 43);
-	x *= C;
-	h += x;
+	x ^= (x >> 57) ^ (x >> 33);
+	h += x * C;
 	h *= C;
 	return h;
 }
@@ -50,10 +69,8 @@ inline uint64_t hash(const uint8_t* buf, size_t len, uint64_t seed) {
 	uint64_t h = (seed + C) ^ len;
 	while (len >= 32) {
 		len -= 32;
-		h = mix_stream(h, *buf64++);
-		h = mix_stream(h, *buf64++);
-		h = mix_stream(h, *buf64++);
-		h = mix_stream(h, *buf64++);
+		h = mix_stream(h, buf64[0], buf64[1], buf64[2], buf64[3]);
+		buf64 += 4;
 	}
 	
 	while (len >= 8) {

--- a/mx3.h
+++ b/mx3.h
@@ -23,7 +23,7 @@ inline uint64_t mix(uint64_t x) {
 
 class random {
 public:
-	explicit random(uint64_t seed) : _counter(seed) {}
+	explicit random(uint64_t seed) : _counter(mix(seed + C)) {}
 	uint64_t operator()() { return mix(_counter++); }
 private:
 	uint64_t _counter;
@@ -47,7 +47,7 @@ inline uint64_t hash(const uint8_t* buf, size_t len, uint64_t seed) {
 	const uint64_t* buf64 = reinterpret_cast<const uint64_t*>(buf);
 	const uint8_t* const tail = reinterpret_cast<const uint8_t*>(buf64 + len/8);
 
-	uint64_t h = seed ^ len;
+	uint64_t h = (seed + C) ^ len;
 	while (len >= 32) {
 		len -= 32;
 		h = mix_stream(h, *buf64++);


### PR DESCRIPTION
- Avoid obvious bad seeds when data length == seed
- Mix the seed of prng to avoid overlaps (e.g. seed 1 would overlap with seed 5 after 4 counter increments).
- Performance improvement for hashing of data of 32 or more bytes (tested with 3 different processors with different compilers and all showed improvement).